### PR TITLE
Correct a typo in "diffusion model.py"

### DIFF
--- a/Diffusion-Model/diffusion model.py
+++ b/Diffusion-Model/diffusion model.py
@@ -159,7 +159,7 @@ def p_sample_loop(model, shape, n_steps, betas, one_minus_alphas_bar_sqrt):
     for i in reversed(range(n_steps)):
         cur_x = p_sample(model, cur_x, i, betas, one_minus_alphas_bar_sqrt)
         x_seq.append(cur_x)
-    return x_seqD
+    return x_seq
 
 
 def p_sample(model, x, t, betas, one_minus_alphas_bar_sqrt):


### PR DESCRIPTION
I have corrected the return value in function `p_sample_loop`, which caused a problem when running the program.
x_seqD is not mentioned in the function. I guess you want to return x_seq instead?